### PR TITLE
Fix missing tmp_cookie_file

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -122,6 +122,7 @@ class Chrome:
 
 class Firefox:
     def __init__(self, cookie_file=None):
+        self.tmp_cookie_file = None
         cookie_file = cookie_file or self.find_cookie_file()
         self.tmp_cookie_file = create_local_copy(cookie_file)
         # current sessions are saved in sessionstore.js
@@ -129,7 +130,8 @@ class Firefox:
            
     def __del__(self):
         # remove temporary backup of sqlite cookie database
-        os.remove(self.tmp_cookie_file)
+        if self.tmp_cookie_file:
+            os.remove(self.tmp_cookie_file)
 
     def __str__(self):
         return 'firefox'


### PR DESCRIPTION
Fixes https://bitbucket.org/richardpenman/browsercookie/issues/5/firefox-issue-on-mac