### PR TITLE
Chrome on windows Support, Bug Fixes, Domain Filtering, Dependency Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Alternatively if you don't know/care which browser has the cookies you want then
 'richardpenman / home &mdash; Bitbucket'
 ```
 
-Alternatively if you are only interested in cookies from a specific domain, you can use the domain function to automatically filter them.
+Alternatively if you are only interested in cookies from a specific domain, you can specify a domain filter.
 ```
 #!python
 
 >>> import browser_cookie3
 >>> import requests
->>> cj = browser_cookie3.domain('www.bitbucket.com')
+>>> cj = browser_cookie3.chrome('www.bitbucket.com')
 >>> r = requests.get(url, cookies=cj)
 >>> get_title(r.content)
 'richardpenman / home &mdash; Bitbucket'
@@ -91,6 +91,13 @@ So far the following platforms are supported:
 * **Chrome:** Linux, OSX, Windows
 * **Firefox:** Linux, OSX, Windows
 
+## Testing Dates  ##
+
+OS      | Chrome | Firefox |
+:------ | :----: | :-----: |
+Mac     | 1/6/16 | 1/6/16  |
+Linux   | 1/6/16 | 1/6/16  |
+Windows | 1/6/16 | n/a     |
 
 However I only tested on a single version of each browser and so am not sure if the cookie sqlite format changes location or format in earlier/later versions. If you experience a problem please [open an issue](https://github.com/borisbabic/browser_cookie3/issues/new) which includes details of the browser version and operating system. Also patches to support other browsers are very welcome, particularly for Chrome and Internet Explorer on Windows.
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,14 @@
 # -*- coding: utf-8 -*-
+"""
+Updates:
+
+* Added support for Chrome on Windows.
+* Fixed an error with Firefox on Mac cookies location.
+* Fixed decode error on Firefox for Linux.
+* Changed dependencies: no longer uses pyCrypto. This is in part because pyCrypto has a lot of dependencies itself and can be difficult to install on some systems, and also because there were already small libraries for just performing the functions that this library needs. Now using pyAES and PBKDF2.
+* Added the domain() function. Simple function that filters results for a single domain if you don't need all of them.
+
+"""
 __doc__ = 'Load browser cookies into a cookiejar'
 
 import os

--- a/__init__.py
+++ b/__init__.py
@@ -1,14 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-Updates:
-
-* Added support for Chrome on Windows.
-* Fixed an error with Firefox on Mac cookies location.
-* Fixed decode error on Firefox for Linux.
-* Changed dependencies: no longer uses pyCrypto. This is in part because pyCrypto has a lot of dependencies itself and can be difficult to install on some systems, and also because there were already small libraries for just performing the functions that this library needs. Now using pyAES and PBKDF2.
-* Added the domain() function. Simple function that filters results for a single domain if you don't need all of them.
-
-"""
 __doc__ = 'Load browser cookies into a cookiejar'
 
 import os


### PR DESCRIPTION
Updates:

* Added support for Chrome on Windows.
* Fixed an error with Firefox on Mac cookies location.
* Fixed decode error on Firefox for Linux.
* Changed dependencies: no longer uses pyCrypto. This is in part because pyCrypto has a lot of dependencies itself and can be difficult to install on some systems, and also because there were already small libraries for just performing the functions that this package needs. Now using pyAES and PBKDF2.
* Added optional domain filtering using sql queries. Useful if you are trying to access only a specific domain.
* Updated the readme to add a section for tracking the last tested date of each browser / os.

A note:
One thing that Jimmy and I discussed a bit while updating the library was the load function, because we think it may introduce unintended behavior in to a program. We weren't sure what would happen during inconsistencies between multiple browsers. Cases where you may be logged in to different accounts for the same domain in either browser, or have out of date cookies in one, etc, could have strange outcomes when signing the same request. We thought we'd point it out as a possible issue.