### PR TITLE
Fix Firefox win32 folder naming conventions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -219,7 +219,7 @@ class Firefox:
                            glob.glob(os.path.join(os.environ.get('PROGRAMFILES(X86)', ''),
                                                   'Mozilla Firefox/profile/cookies.sqlite')) or \
                            glob.glob(os.path.join(os.environ.get('APPDATA', ''),
-                                                  'Mozilla/Firefox/Profiles/*.default/cookies.sqlite'))
+                                                  'Mozilla/Firefox/Profiles/*.default*/cookies.sqlite'))
         else:
             raise BrowserCookieError('Unsupported operating system: ' + sys.platform)
         if cookie_files:


### PR DESCRIPTION
.default may be followed by additional characters. This correctly locates profile folder.