### PR TITLE
Support profiles for firefox dev edition

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -224,18 +224,18 @@ class Firefox:
     def find_cookie_file():
         if sys.platform == 'darwin':
             cookie_files = glob.glob(
-                os.path.expanduser('~/Library/Application Support/Firefox/Profiles/*.default/cookies.sqlite'))
+                os.path.expanduser('~/Library/Application Support/Firefox/Profiles/*default/cookies.sqlite'))
         elif sys.platform.startswith('linux'):
-            cookie_files = glob.glob(os.path.expanduser('~/.mozilla/firefox/*.default/cookies.sqlite'))
+            cookie_files = glob.glob(os.path.expanduser('~/.mozilla/firefox/*default/cookies.sqlite'))
         elif sys.platform == 'win32':
             cookie_files = glob.glob(os.path.join(os.environ.get('PROGRAMFILES', ''), 
                                                     'Mozilla Firefox/profile/cookies.sqlite')) \
                             or glob.glob(os.path.join(os.environ.get('PROGRAMFILES(X86)', ''),
                                                     'Mozilla Firefox/profile/cookies.sqlite')) \
                             or glob.glob(os.path.join(os.environ.get('APPDATA', ''),
-                                                    'Mozilla/Firefox/Profiles/*.default*/cookies.sqlite')) \
+                                                    'Mozilla/Firefox/Profiles/*default*/cookies.sqlite')) \
                             or glob.glob(os.path.join(os.environ.get('LOCALAPPDATA', ''),
-                                                    'Mozilla/Firefox/Profiles/*.default*/cookies.sqlite'))
+                                                    'Mozilla/Firefox/Profiles/*default*/cookies.sqlite'))
         else:
             raise BrowserCookieError('Unsupported operating system: ' + sys.platform)
         if cookie_files:


### PR DESCRIPTION
Firefox Developer Edition has a different naming scheme for profile folders:

![image](https://user-images.githubusercontent.com/25161069/56930671-61a08980-6ad5-11e9-8109-feabf8329dc0.png)

In this case, I have Firefox Developer Edition installed, but not Firefox itself. This would cause `browser_cookie3.firefox()` to fail, since it can't find a folder ending in `.default` which contains a cookie file.