### PR TITLE
Support for newer firefox

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -9,6 +9,7 @@ import http.cookiejar
 import tempfile
 import configparser
 import re
+import datetime
 
 try:
     import json
@@ -168,8 +169,13 @@ class Chrome:
                         'FROM cookies WHERE host_key like "%{}%";'.format(self.domain_name))
 
         cj = http.cookiejar.CookieJar()
+        epoch_start = datetime.datetime(1601,1,1)
         for item in cur.fetchall():
             host, path, secure, expires, name = item[:5]
+            if item[3] != 0:
+                delta = datetime.timedelta(microseconds=int(item[3]))
+                expires = epoch_start + delta
+                expires = expires.timestamp()
             value = self._decrypt(item[5], item[6])
             c = create_cookie(host, path, secure, expires, name, value)
             cj.set_cookie(c)

--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,6 @@ import time
 import glob
 import http.cookiejar
 import tempfile
-import configparser
 import re
 import datetime
 
@@ -23,6 +22,7 @@ except ImportError:
     import sqlite3
 
 # external dependencies
+import configparser
 import keyring
 import pyaes
 try:

--- a/__init__.py
+++ b/__init__.py
@@ -230,25 +230,24 @@ class Firefox:
     def __str__(self):
         return 'firefox'
 
-    @staticmethod
-    def find_cookie_file():
+    def find_cookie_file(self):
         if sys.platform == 'darwin':
+            profiles_ini_paths = glob.glob(os.path.expanduser('~/Library/Application Support/Firefox/profiles.ini'))
+            profiles_ini_path = self.get_default_profile(profiles_ini_paths)
             cookie_files = glob.glob(
-                os.path.expanduser('~/Library/Application Support/Firefox/Profiles/*default/cookies.sqlite'))
+                os.path.expanduser('~/Library/Application Support/Firefox/Profiles/*default/cookies.sqlite')) \
+                or os.path.expanduser('~/Library/Application Support/Firefox/Profiles/{0}/cookies.sqlite'.format(profiles_ini_path))
         elif sys.platform.startswith('linux'):
-            cookie_files = glob.glob(os.path.expanduser('~/.mozilla/firefox/*default*/cookies.sqlite'))
+            profiles_ini_paths = glob.glob(os.path.expanduser('~/.mozilla/firefox/profiles.ini'))
+            profiles_ini_path = self.get_default_profile(profiles_ini_paths)
+            cookie_files = glob.glob(os.path.expanduser('~/.mozilla/firefox/*default*/cookies.sqlite')) \
+                            or glob.glob(os.path.expanduser('~/.mozilla/firefox/{0}/cookies.sqlite'.format(profiles_ini_path)))
         elif sys.platform == 'win32':
-            profiles_ini_path = glob.glob(os.path.join(os.environ.get('APPDATA', ''),
+            profiles_ini_paths = glob.glob(os.path.join(os.environ.get('APPDATA', ''),
                                                     'Mozilla/Firefox/profiles.ini')) \
-                            or glob.glob(os.path.join(os.environ.get('LOCALAPPDATA', ''),
+                                    or glob.glob(os.path.join(os.environ.get('LOCALAPPDATA', ''),
                                                     'Mozilla/Firefox/profiles.ini'))
-            config = configparser.ConfigParser()
-            config.read(profiles_ini_path)
-            profile_path = "dummy"
-            for section in config.sections():
-                if re.match('Install.*', section) is not None:
-                    profile_path = config[section]['Default']
-
+            profiles_ini_path = self.get_default_profile(profiles_ini_paths)
             cookie_files = glob.glob(os.path.join(os.environ.get('PROGRAMFILES', ''), 
                                                     'Mozilla Firefox/profile/cookies.sqlite')) \
                             or glob.glob(os.path.join(os.environ.get('PROGRAMFILES(X86)', ''),
@@ -258,7 +257,7 @@ class Firefox:
                             or glob.glob(os.path.join(os.environ.get('LOCALAPPDATA', ''),
                                                     'Mozilla/Firefox/Profiles/*default*/cookies.sqlite')) \
                             or glob.glob(os.path.join(os.environ.get('APPDATA', ''),
-                                                    "Mozilla/Firefox/{0}/cookies.sqlite".format(profile_path)))
+                                                    "Mozilla/Firefox/{0}/cookies.sqlite".format(profiles_ini_path)))
         else:
             raise BrowserCookieError('Unsupported operating system: ' + sys.platform)
         if cookie_files:
@@ -305,9 +304,22 @@ class Firefox:
 
         return cj
 
+    def get_default_profile(self, profiles_ini_path):
+        """ Given the path to firefox profiles.ini,
+            will return relative path to firefox default profile
+        """
+        config = configparser.ConfigParser()
+        config.read(profiles_ini_path)
+        profiles_path = "dummy"
+        for section in config.sections():
+            if re.match('Install.*', section) is not None:
+                profiles_path = config[section]['Default']
+        return profiles_path
+
     def mozlz4_to_text(self, filepath):
-        # Given the path to a "mozlz4", "jsonlz4", "baklz4" etc. file, 
-        # return the uncompressed text.
+        """Given the path to a "mozlz4", "jsonlz4", "baklz4" etc. file, 
+           return the uncompressed text.
+        """
         bytestream = open(filepath, "rb")
         if bytestream.read(8) != b"mozLz40\0":
             print('Error parsing firefox recovery JSONLZ4 - Invalid Header')

--- a/__init__.py
+++ b/__init__.py
@@ -286,9 +286,10 @@ class Firefox:
                 expires = str(int(time.time()) + 3600 * 24 * 7)
                 for window in json_data.get('windows', []):
                     for cookie in window.get('cookies', []):
-                        c = create_cookie(cookie.get('host', ''), cookie.get('path', ''), False, expires,
-                                          cookie.get('name', ''), cookie.get('value', ''))
-                        cj.set_cookie(c)
+                        if cookie.get('host') == self.domain_name:
+                            c = create_cookie(cookie.get('host', ''), cookie.get('path', ''), False, expires,
+                                            cookie.get('name', ''), cookie.get('value', ''))
+                            cj.set_cookie(c)
 
         if os.path.exists(self.recovery_file):
             try:
@@ -298,9 +299,10 @@ class Firefox:
             else:
                 expires = str(int(time.time()) + 3600 * 24 * 7)
                 for cookie in json_data.get('cookies', []):
-                    c = create_cookie(cookie.get('host', ''), cookie.get('path', ''), False, expires,
-                                      cookie.get('name', ''), cookie.get('value', ''))
-                    cj.set_cookie(c)
+                    if cookie.get('host') == self.domain_name:
+                        c = create_cookie(cookie.get('host', ''), cookie.get('path', ''), False, expires,
+                                        cookie.get('name', ''), cookie.get('value', ''))
+                        cj.set_cookie(c)
 
         return cj
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,11 @@ setup(
     author_email='boris.ivan.babic@gmail.com',
     description='Loads cookies from your browser into a cookiejar object so can download with urllib and other libraries the same content you see in the web browser.',
     url='https://github.com/borisbabic/browser_cookie3',
-    install_requires=['pyaes','pbkdf2','keyring'],
-    license='lgpl'
+    install_requires=['pyaes','pbkdf2','keyring','lz4','configparser'],
+    license='lgpl',
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
+        "Operating System :: OS Independent",
+    ]
 )


### PR DESCRIPTION
This PR adds few features for Firefox.
- look into profiles.ini for Firefox Default profile; usefull if profile is not named *.default
- look into Firefox session recovery files to get Session cookies as from FF 33+ the `sessionstore.js` is no longer used