### PR TITLE
#31 add support for mozilla's custom lz4 session backup format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     author_email='boris.ivan.babic@gmail.com',
     description='Loads cookies from your browser into a cookiejar object so can download with urllib and other libraries the same content you see in the web browser.',
     url='https://github.com/borisbabic/browser_cookie3',
-    install_requires=['pyaes','pbkdf2','keyring'],
+    install_requires=['pyaes','pbkdf2','keyring','lz4'],
     license='lgpl'
 )


### PR DESCRIPTION
This PR fixes issue #31 by adding the ability to read firefox session information from the new `recovery.jsonlz4` session storage file, without breaking compatibility with the previous implementation. Both methods coexist independently to make it easier to sunset `sessionstore.js` in the future, should the choice be made to drop support for older firefox installations.