### PR TITLE
Fix getting default profile of Firefox on Darwin

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -252,7 +252,7 @@ class Firefox:
     def find_cookie_file(self):
         if sys.platform == 'darwin':
             profiles_ini_paths = glob.glob(os.path.expanduser('~/Library/Application Support/Firefox/profiles.ini'))
-            profiles_ini_path = self.get_default_profile(profiles_ini_paths, os.path.expanduser('~/Library/Application Support/Firefox/Profiles/{0}/cookies.sqlite'.format(profiles_ini_path)))
+            profiles_ini_path = self.get_default_profile(profiles_ini_paths, os.path.expanduser('~/Library/Application Support/Firefox/{0}/cookies.sqlite'))
             cookie_files = glob.glob(
                 os.path.expanduser('~/Library/Application Support/Firefox/Profiles/*default/cookies.sqlite')) \
                 or glob.glob(profiles_ini_path)


### PR DESCRIPTION
the original implementation crashes on line 255 with "UnboundLocalError: local variable 'profiles_ini_path' referenced before assignment". the format function call on template is not necessary, and the 'Profiles' in template is redundant.

tested on macOS Catalina 10.15.2 with Firefox 71.0