### PR TITLE
Fix get_default_profile in Firefox

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -247,7 +247,7 @@ class Firefox:
                     return template_for_relative.format(config[section]['Path'])
             except KeyError:
                 continue
-        return none
+        return None
 
     def find_cookie_file(self):
         if sys.platform == 'darwin':


### PR DESCRIPTION
Fixes this error:
```
Traceback (most recent call last):
  File "dl.py", line 8, in <module>
    cj = browser_cookie3.firefox()
  File "/usr/lib/python3.7/site-packages/browser_cookie3/__init__.py", line 354, in firefox
    return Firefox(cookie_file, domain_name).load()
  File "/usr/lib/python3.7/site-packages/browser_cookie3/__init__.py", line 221, in __init__
    cookie_file = cookie_file or self.find_cookie_file()
  File "/usr/lib/python3.7/site-packages/browser_cookie3/__init__.py", line 261, in find_cookie_file
    profiles_ini_path = self.get_default_profile(profiles_ini_paths, os.path.expanduser('~/.mozilla/firefox/{0}/cookies.sqlite'))
  File "/usr/lib/python3.7/site-packages/browser_cookie3/__init__.py", line 250, in get_default_profile
    return none
NameError: name 'none' is not defined
```