### PR TITLE
#40 fix cookie lookup in FF 72.0.1 or when profiles.ini does not exist

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -265,7 +265,7 @@ class Firefox:
 
         profile_name = Firefox.get_default_profile(profiles_prefix)
         cookie_files = glob.glob(os.path.join(profiles_prefix, profile_name or '*', 'cookies.sqlite')) \
-            or glob.glob(Firefox.get_default_profile(profiles_prefix, True)) \
+            or glob.glob(Firefox.get_default_profile(profiles_prefix, True) or '') \
             or cookie_files
 
         if cookie_files:

--- a/__init__.py
+++ b/__init__.py
@@ -264,7 +264,7 @@ class Firefox:
             raise BrowserCookieError('Unsupported operating system: ' + sys.platform)
 
         profile_name = Firefox.get_default_profile(profiles_prefix)
-        cookie_files = glob.glob(os.path.join(profiles_prefix, profile_name, 'cookies.sqlite')) \
+        cookie_files = glob.glob(os.path.join(profiles_prefix, profile_name or '*', 'cookies.sqlite')) \
             or glob.glob(Firefox.get_default_profile(profiles_prefix, True)) \
             or cookie_files
 

--- a/__init__.py
+++ b/__init__.py
@@ -251,9 +251,8 @@ class Firefox:
         elif sys.platform.startswith('linux'):
             profiles_prefix = os.path.expanduser('~/.mozilla/firefox/')
         elif sys.platform == 'win32':
-            app_data_paths = list(map(os.environ.get, ['APPDATA', 'LOCALAPPDATA']))
-            profiles_prefix = glob.glob(os.path.join(app_data_paths[0], 'Mozilla', 'Firefox', 'Profiles')) \
-                or glob.glob(os.path.join(app_data_paths[1], 'Mozilla', 'Firefox', 'Profiles'))
+            profiles_prefix = glob.glob(os.path.join(os.environ.get('APPDATA'), 'Mozilla', 'Firefox', 'Profiles')) \
+                or glob.glob(os.path.join(os.environ.get('LOCALAPPDATA'), 'Mozilla', 'Firefox', 'Profiles'))
             # legacy firefox <68 fallback
             programs_paths = list(map(os.environ.get, ['PROGRAMFILES', 'PROGRAMFILES(X86)']))
             cookie_files = glob.glob(os.path.join(programs_paths[0], 'Mozilla Firefox', 'profile', 'cookies.sqlite')) \

--- a/__init__.py
+++ b/__init__.py
@@ -256,10 +256,10 @@ class Firefox:
             profiles_prefix = os.path.expanduser('~/.mozilla/firefox/')
         elif sys.platform == 'win32':
             app_data_path = to_glob_pattern('APPDATA', 'LOCALAPPDATA')
-            profiles_prefix = os.path.join(app_data_path, 'Mozilla/Firefox/Profiles')
+            profiles_prefix = os.path.join(app_data_path, 'Mozilla', 'Firefox', 'Profiles')
             # legacy firefox <68 fallback
             program_files_path = to_glob_pattern('PROGRAMFILES', 'PROGRAMFILES(X86)')
-            cookie_files = glob.glob(os.path.join(program_files_path, 'Mozilla Firefox/profile/cookies.sqlite'))
+            cookie_files = glob.glob(os.path.join(program_files_path, 'Mozilla Firefox', 'profile', 'cookies.sqlite'))
         else:
             raise BrowserCookieError('Unsupported operating system: ' + sys.platform)
 

--- a/__init__.py
+++ b/__init__.py
@@ -254,8 +254,7 @@ class Firefox:
         elif sys.platform.startswith('linux'):
             user_data_path = os.path.expanduser('~/.mozilla/firefox')
         elif sys.platform == 'win32':
-            user_data_path = glob.glob(os.path.join(os.environ.get('APPDATA'), 'Mozilla', 'Firefox')) \
-                or glob.glob(os.path.join(os.environ.get('LOCALAPPDATA'), 'Mozilla', 'Firefox'))
+            user_data_path = glob.glob(os.path.join(os.environ.get('APPDATA'), 'Mozilla', 'Firefox'))
             # legacy firefox <68 fallback
             cookie_files = glob.glob(os.path.join(os.environ.get('PROGRAMFILES'), 'Mozilla Firefox', 'profile', 'cookies.sqlite')) \
                 or glob.glob(os.path.join(os.environ.get('PROGRAMFILES(X86)'), 'Mozilla Firefox', 'profile', 'cookies.sqlite'))

--- a/__init__.py
+++ b/__init__.py
@@ -240,7 +240,7 @@ class Firefox:
 
         profile_path = None
         for section in config.sections():
-            if config[section].startswith('Install'):
+            if section.startswith('Install'):
                 profile_path = config[section].get('Path')
                 break
             # in ff 72.0.1, if both an Install section and one with Default=1 are present, the former takes precedence

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='browser-cookie3',
-    version='0.9.0',
+    version='0.9.1',
     packages=['browser_cookie3'],
     package_dir={'browser_cookie3' : '.'}, # look for package contents in current directory
     author='Boris Babic',

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     version='0.9.1',
     packages=['browser_cookie3'],
     package_dir={'browser_cookie3' : '.'}, # look for package contents in current directory
+    zip_safe=False,
     author='Boris Babic',
     author_email='boris.ivan.babic@gmail.com',
     description='Loads cookies from your browser into a cookiejar object so can download with urllib and other libraries the same content you see in the web browser.',


### PR DESCRIPTION
this PR fixes issue #40 and is also a small refactor of the way firefox profiles are searched for.
(edit: this commit also fixes the issue mentioned in #37 as a side effect.)

while testing a utility i am making using browser-cookie3 in my own windows vm and my client's computer, i came across different firefox behaviours that are unaccounted for:

72.0.1 and 68.4.1esr 32-bit
`profiles.ini` got propped up to the Parent of profiles, with relative paths being prepended by 'Profiles/'
`profiles.ini` `Default=1` flag gets ignored when it contradicts the value of [Install<id>] section 


this PR covers these cases while maintaining backwards compatibility.

here's the new flow:
- get the user data folder
- find _any_ file named `profiles.ini` under the user data folder (at any depth), and parse it to get the active profile
- compose the found location of the profile in relation to the location of `profiles.ini` if `IsRelative=1`
- if the default profile can't be found through profiles.ini, find _any_ file named `cookies.sqlite` under the user data folder (at any depth)

i have also removed `APPDATALOCAL` from the windows search alternatives as per https://support.mozilla.org/en-US/questions/1174885, which documents that cookies have not been stored there since at the very least over two years ago but likely much longer than that.

this PR has been tested in linux and a couple of different windows firefox installs.