### PR TITLE
Windows + Chrome v80 encryption update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/*.swp
+__pycache__
+*.pyc

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     author_email='boris.ivan.babic@gmail.com',
     description='Loads cookies from your browser into a cookiejar object so can download with urllib and other libraries the same content you see in the web browser.',
     url='https://github.com/borisbabic/browser_cookie3',
-    install_requires=['pyaes','pbkdf2','keyring','lz4'],
+    install_requires=['pyaes','pbkdf2','keyring','lz4', 'pycryptodome'],
     license='lgpl'
 )


### PR DESCRIPTION
Updated to work with Chrome v80's new encryption method in Windows (try DPAPI, except try AES)
Updated timestamp with try/except to catch Windows 7 limitation