### PR TITLE
Catch one more gobject exception

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -116,7 +116,7 @@ def get_linux_pass(browser="Chrome"):
 
         gi.require_version("Secret", "1")
         from gi.repository import Secret
-    except ImportError:
+    except (ImportError, AttributeError):
         pass
     else:
         flags = Secret.ServiceFlags.LOAD_COLLECTIONS


### PR DESCRIPTION
On Arch Linux, the gi package is provided by libibus while gi.require_version
is provided by python-gobject. Catch the following exception to use another
backend when python-gobject is not installed.

```
In [1]: import gi

In [2]: gi.require_version("Secret", "1")
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-f1d223eb7694> in <module>
----> 1 gi.require_version("Secret", "1")

AttributeError: module 'gi' has no attribute 'require_version'
```