### PR TITLE
Support Microsoft Edge and other chromium based Browsers.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -157,7 +157,7 @@ def get_linux_pass(browser="Chrome"):
 
 
 class Chrome:
-    def __init__(self, key_file=None, cookie_file=None, domain_name=""):
+    def __init__(self, cookie_file=None, domain_name="", key_file=None):
         self.salt = b'saltysalt'
         self.iv = b' ' * 16
         self.length = 16
@@ -458,11 +458,11 @@ def create_cookie(host, path, secure, expires, name, value):
                                  True, secure, expires, False, None, None, {})
 
 
-def chrome(key_file=None, cookie_file=None, domain_name=""):
+def chrome(cookie_file=None, domain_name="", key_file=None):
     """Returns a cookiejar of the cookies used by Chrome. Optionally pass in a
     domain name to only load cookies from the specified domain
     """
-    return Chrome(key_file, cookie_file, domain_name).load()
+    return Chrome(cookie_file, domain_name, key_file).load()
 
 
 def firefox(cookie_file=None, domain_name=""):

--- a/__init__.py
+++ b/__init__.py
@@ -157,7 +157,7 @@ def get_linux_pass(browser="Chrome"):
 
 
 class Chrome:
-    def __init__(self, cookie_file=None, domain_name=""):
+    def __init__(self, key_file=None, cookie_file=None, domain_name=""):
         self.salt = b'saltysalt'
         self.iv = b' ' * 16
         self.length = 16
@@ -190,7 +190,7 @@ class Chrome:
         elif sys.platform == "win32":
 
             # Read key from file
-            key_file = glob.glob(os.path.join(os.getenv('APPDATA', ''), '..\Local\\Google\\Chrome\\User Data\\Local State')) \
+            key_file = key_file or glob.glob(os.path.join(os.getenv('APPDATA', ''), '..\Local\\Google\\Chrome\\User Data\\Local State')) \
                 or glob.glob(os.path.join(os.getenv('LOCALAPPDATA', ''), 'Google\\Chrome\\User Data\\Local State')) \
                 or glob.glob(os.path.join(os.getenv('APPDATA', ''), 'Google\\Chrome\\User Data\\Local State'))
 
@@ -458,11 +458,11 @@ def create_cookie(host, path, secure, expires, name, value):
                                  True, secure, expires, False, None, None, {})
 
 
-def chrome(cookie_file=None, domain_name=""):
+def chrome(key_file=None, cookie_file=None, domain_name=""):
     """Returns a cookiejar of the cookies used by Chrome. Optionally pass in a
     domain name to only load cookies from the specified domain
     """
-    return Chrome(cookie_file, domain_name).load()
+    return Chrome(key_file, cookie_file, domain_name).load()
 
 
 def firefox(cookie_file=None, domain_name=""):


### PR DESCRIPTION
As different chromium-based browsers have 'key_file' and 'cookie_file' in a different directory, allowing to specify the 'key_file' and 'cookie_file' supports other chromium-based browsers too.

**Example:**
_To extract cookie from Microsoft Edge, we can manually specify 'key_file' and 'cookie_file' as below:_

`cj = browser_cookie3.chrome(key_file='C:\\Users\\USERNAME\\AppData\\Local\\Microsoft\\Edge\\User Data\\Local State', cookie_file='C:\\Users\\USERNAME\\AppData\\Local\\Microsoft\\Edge\\User Data\\Default\\cookies', domain_name='www.bitbucket.com')`