### PR TITLE
make browser_cookie3 work with Chromium v80, not just Chrome v80

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -173,25 +173,34 @@ class Chrome:
 
         elif sys.platform.startswith('linux'):
             # running Chrome on Linux
-            # chrome linux is encrypted with the key peanuts
             for name in ('Chrome', 'Chromium'):
                 my_pass = get_linux_pass(name)
                 if my_pass is not None:
                     my_pass = my_pass.encode('utf8')
+                    if name == 'Chromium':
+                        paths = map(os.path.expanduser, [
+                            '~/.config/chromium/Default/Cookies',
+                        ])
+                    else:
+                        paths = map(os.path.expanduser, [
+                            '~/.config/google-chrome/Default/Cookies',
+                            '~/.config/google-chrome-beta/Default/Cookies'
+                        ])
                     break
             else:
-                # try default
+                # try default key 'peanuts' with all possible paths (probably won't work)
                 my_pass = 'peanuts'
+                paths = map(os.path.expanduser, [
+                    '~/.config/google-chrome/Default/Cookies',
+                    '~/.config/chromium/Default/Cookies',
+                    '~/.config/google-chrome-beta/Default/Cookies'
+                ])
             iterations = 1
             self.key = PBKDF2(my_pass, self.salt,
                               iterations=iterations).read(self.length)
-            paths = map(os.path.expanduser, [
-                '~/.config/google-chrome/Default/Cookies',
-                '~/.config/chromium/Default/Cookies',
-                '~/.config/google-chrome-beta/Default/Cookies'
-            ])
             cookie_file = cookie_file or next(
                 filter(os.path.exists, paths), None)
+
         elif sys.platform == "win32":
 
             # Read key from file

--- a/__init__.py
+++ b/__init__.py
@@ -152,8 +152,6 @@ def get_linux_pass(browser="Chrome"):
 
     if my_pass:
         return my_pass
-    else:
-        return "peanuts"
 
 
 class Chrome:
@@ -176,7 +174,14 @@ class Chrome:
         elif sys.platform.startswith('linux'):
             # running Chrome on Linux
             # chrome linux is encrypted with the key peanuts
-            my_pass = get_linux_pass().encode('utf8')
+            for name in ('Chrome', 'Chromium'):
+                my_pass = get_linux_pass(name)
+                if my_pass is not None:
+                    my_pass = my_pass.encode('utf8')
+                    break
+            else:
+                # try default
+                my_pass = 'peanuts'
             iterations = 1
             self.key = PBKDF2(my_pass, self.salt,
                               iterations=iterations).read(self.length)


### PR DESCRIPTION
It appears that they are 100% identical, except for the name of the keyring where the password is stored.

Should close #55.