### PR TITLE
Add None check for non chrome users

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -218,6 +218,10 @@ class Chrome:
             raise BrowserCookieError(
                 "OS not recognized. Works on Chrome for OSX, Windows, and Linux.")
 
+        # if the cookie_file is None, could not find a Chrome cookie
+        if cookie_file is None:
+            raise BrowserCookieError('Failed to find Chrome cookie')
+        
         # if the type of cookie_file is list, use the first element in the list
         if isinstance(cookie_file, list):
             if not cookie_file:


### PR DESCRIPTION
Thanks for the great library!

when using browser_cookie3 without chrome installed, the `load` call (line 481 of this PR) will attempt to load a cookie file from Chrome first. If Chrome is not installed, the `Chrome.__init__()` method will generate a NoneType for the cookie file. This is problematic when this method calls `create_local_copy`, which throws a TypeError when `os.path.exists` is passed None. 