### PR TITLE
Fix secure value when importing a firefox cookie.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -422,7 +422,8 @@ class Firefox:
     @staticmethod
     def __create_session_cookie(cookie_json):
         expires = str(int(time.time()) + 3600 * 24 * 7)
-        return create_cookie(cookie_json.get('host', ''), cookie_json.get('path', ''), False, expires,
+        return create_cookie(cookie_json.get('host', ''), cookie_json.get('path', ''),
+                             cookie_json.get('secure', False), expires,
                              cookie_json.get('name', ''), cookie_json.get('value', ''))
 
     def __add_session_cookies(self, cj):


### PR DESCRIPTION
Add `secure` value when importing a firefox cookie from the recovery file.