### PR TITLE
Fix use of double-quoted strings in SQLite queries

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -266,11 +266,11 @@ class ChromiumBased:
         try:
             # chrome <=55
             cur.execute('SELECT host_key, path, secure, expires_utc, name, value, encrypted_value '
-                        'FROM cookies WHERE host_key like "%{}%";'.format(self.domain_name))
+                        'FROM cookies WHERE host_key like ?;', ('%{}%'.format(self.domain_name),))
         except sqlite3.OperationalError:
             # chrome >=56
             cur.execute('SELECT host_key, path, is_secure, expires_utc, name, value, encrypted_value '
-                        'FROM cookies WHERE host_key like "%{}%";'.format(self.domain_name))
+                        'FROM cookies WHERE host_key like ?;', ('%{}%'.format(self.domain_name),))
 
         cj = http.cookiejar.CookieJar()
         epoch_start = datetime.datetime(1601, 1, 1)
@@ -570,7 +570,7 @@ class Firefox:
         con = sqlite3.connect(self.tmp_cookie_file)
         cur = con.cursor()
         cur.execute('select host, path, isSecure, expiry, name, value from moz_cookies '
-                    'where host like "%{}%"'.format(self.domain_name))
+                    'where host like ?', ('%{}%'.format(self.domain_name),))
 
         cj = http.cookiejar.CookieJar()
         for item in cur.fetchall():


### PR DESCRIPTION
Double-quotes are used for identifiers, not strings. While SQLite will interpret unknown identifiers that use double-quotes as strings, this is considered a misfeature. This commit fixes the SQL for those of us with double-quoted strings disabled and fixes setting domain_name to the name of a column in the SQLite table.