### PR TITLE
Chrome v96 cookie path

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -369,9 +369,9 @@ class Chrome(ChromiumBased):
                     '~/.config/google-chrome-beta/Default/Cookies'
                 ],
             'windows_cookies':[
-                    {'env':'APPDATA', 'path':'..\\Local\\Google\\Chrome\\User Data\\Default\\Cookies'},
-                    {'env':'LOCALAPPDATA', 'path':'Google\\Chrome\\User Data\\Default\\Cookies'},
-                    {'env':'APPDATA', 'path':'Google\\Chrome\\User Data\\Default\\Cookies'}
+                    {'env':'APPDATA', 'path':'..\\Local\\Google\\Chrome\\User Data\\Default\\Network\\Cookies'},
+                    {'env':'LOCALAPPDATA', 'path':'Google\\Chrome\\User Data\\Default\\Network\\Cookies'},
+                    {'env':'APPDATA', 'path':'Google\\Chrome\\User Data\\Default\\Network\\Cookies'}
                 ],
             'osx_cookies': ['~/Library/Application Support/Google/Chrome/Default/Cookies'],
             'windows_keys': [


### PR DESCRIPTION
Changed windows_cookies path in lines 372-374 to work with Chrome v96 from `...\\Default\\Cookies` to `...\\Default\\Network\\Cookies`
Chrome 96 release notes: 
https://support.google.com/chrome/a/answer/7679408?hl=en#:~:text=Network%20data%20moves%20to%20a%20new%20folder%20on%20Windows%C2%A0%20%C2%A0

Not sure if other paths need to be changed, I changed these only and it has worked for my situation. 

Sorry if the formatting is weird, this is my first change proposal.