### PR TITLE
Specify encoding when reading profiles.ini

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -522,7 +522,7 @@ class Firefox:
             return fallback_path
 
         profiles_ini_path = profiles_ini_path[0]
-        config.read(profiles_ini_path)
+        config.read(profiles_ini_path, encoding="utf8")
 
         profile_path = None
         for section in config.sections():


### PR DESCRIPTION
Fix decode error when firefox profile path contains non-ASCII character and system text encoding is not utf-8.

mabe fix https://github.com/borisbabic/browser_cookie3/issues/85