### PR TITLE
Update __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -365,7 +365,9 @@ class Chrome(ChromiumBased):
             'windows_cookies':[
                     {'env':'APPDATA', 'path':'..\\Local\\Google\\Chrome\\User Data\\Default\\Cookies'},
                     {'env':'LOCALAPPDATA', 'path':'Google\\Chrome\\User Data\\Default\\Cookies'},
-                    {'env':'APPDATA', 'path':'Google\\Chrome\\User Data\\Default\\Cookies'}
+                    {'env':'APPDATA', 'path':'Google\\Chrome\\User Data\\Default\\Cookies'},
+                    {'env':'LOCALAPPADATA', 'path':'Google\\Chrome\\User Data\\Default\\Network\\Cookies'},
+                    {'env':'APPDATA', 'path':'Google\\Chrome\\User Data\\Default\\Network\\Cookies'}
                 ],
             'osx_cookies': ['~/Library/Application Support/Google/Chrome/Default/Cookies'],
             'windows_keys': [


### PR DESCRIPTION
The Cookies file could be located in "%LOCALAPPDATA%\Google\Chrome\User Data\Default\Network" and it doesn't look for the Cookies file inside of the Network directory. I ran into this issue and I don't believe everybody will have this issue but some might have it and this is a fix.