### PR TITLE
Fix incorrect default profile path (#125)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -536,8 +536,8 @@ class Firefox:
         profile_path = None
         for section in config.sections():
             if section.startswith('Install'):
+                # Use that last Install section
                 profile_path = config[section].get('Default')
-                break
             # in ff 72.0.1, if both an Install section and one with Default=1 are present, the former takes precedence
             elif config[section].get('Default') == '1' and not profile_path:
                 profile_path = config[section].get('Path')


### PR DESCRIPTION
With Firefox, there can be multiple Install sections and the last
one seems to be the default.

Signed-off-by: Juerg Haefliger <juergh@protonmail.com>