### PR TITLE
Added support for KDE Wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 0.14.2
+- [Chromium based] Added support for KDE Wallet
 ### 0.14.1
 - [Chromium based] Added Chromium v96 cookie paths
 - [MODULE] Replaced deprecated `distutils` with `setuptools`

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='browser-cookie3',
-    version='0.14.1',
+    version='0.14.2',
     packages=['browser_cookie3'],
     # look for package contents in current directory
     package_dir={'browser_cookie3': '.'},


### PR DESCRIPTION
The current implementation of chromium password storage on KDE doesn't actually have anything save on KDEWallet. Thus using `keyring` to retrieve the password on KDE throws an error. But `dbus` (which chromium uses under the hood) returns an empty string if nothing is saved. Thus chromium essentially encrypts the cookies using an empty key on KDE. Another problem with using `keyring` to retrieve the password for Linux is, `keyring` is required to have `gnome-keyring` installed on the system. But some distros like KDE-based ones don't use `gnome-keyring`.

I've implemented getting the key from the KDE wallet using dbus. This should work even after chromium fixes the bug of not saving anything.