### PR TITLE
fix resource warning about unclosed file

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -42,7 +42,8 @@ def create_local_copy(cookie_file):
     if os.path.exists(cookie_file):
         # copy to random name in tmp folder
         tmp_cookie_file = tempfile.NamedTemporaryFile(suffix='.sqlite').name
-        open(tmp_cookie_file, 'wb').write(open(cookie_file, 'rb').read())
+        with open(tmp_cookie_file, "wb") as f1, open(cookie_file, "rb") as f2:
+            f1.write(f2.read())
         return tmp_cookie_file
     else:
         raise BrowserCookieError('Can not find cookie file at: ' + cookie_file)


### PR DESCRIPTION
Every time I'm using this package it spams warnings like

```
/Users/wim/git/scratch/.venv/lib/python3.10/site-packages/browser_cookie3/__init__.py:45: ResourceWarning: unclosed file <_io.BufferedReader name='/Users/wim/Library/Application Support/Google/Chrome/Default/Cookies'>
  open(tmp_cookie_file, 'wb').write(open(cookie_file, 'rb').read())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/wim/git/scratch/.venv/lib/python3.10/site-packages/browser_cookie3/__init__.py:45: ResourceWarning: unclosed file <_io.BufferedWriter name='/var/folders/l9/gsl6q67557s4vd8gh4pkqt2c0000gn/T/tmp7jyeeys4.sqlite'>
  open(tmp_cookie_file, 'wb').write(open(cookie_file, 'rb').read())
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

This should fix those