### PR TITLE
fix safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 0.16.0
+- [MODULE] Added new browser support: Safari
 ### 0.15.0
 - [MODULE] Added new browser support: Vivaldi
 - [Chromium based] Fix profile path channge for macOS Monterey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.15.0
+- [MODULE] Added new browser support: Vivaldi
+- [Chromium based] Fix profile path channge for macOS Monterey
+### 0.14.3
+- [Chromium based] Fix for mixture of `v10` and `v11` cookies on linux
 ### 0.14.2
 - [Chromium based] Added support for KDE Wallet
 ### 0.14.1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a python3 fork of [Richard Penman's Browser Cookie](https://github.com/r
 
 * ***What does it do?*** Loads cookies used by your web browser into a cookiejar object.
 * ***Why is it useful?*** This means you can use python to download and get the same content you see in the web browser without needing to login.
-* ***Which browsers are supported?*** Currently Chrome, Firefox, Opera, Edge, Chromium, Brave, and Vivaldi.
+* ***Which browsers are supported?*** Currently Chrome, Firefox, Opera, Edge, Chromium, Brave, Vivaldi, and Safari.
 * ***How are the cookies stored?*** All currently-supported browsers store cookies in a sqlite database in your home directory.
 
 ## Install ##
@@ -106,16 +106,17 @@ So far the following platforms are supported:
 * **Opera:** Linux, OSX, Windows
 * **Edge:** Linux, OSX, Windows
 * **Chromium:** Linux, OSX, Windows
-* **Brave** Linux, OSX, Windows
-* **Vivaldi** Linux, OSX, Windows
+* **Brave:** Linux, OSX, Windows
+* **Vivaldi:** Linux, OSX, Windows
+* **Safari:** OSX
 
 ## Testing Dates  (dd/mm/yy) ##
 
-OS      |  Chrome  | Firefox  |  Opera   |   Edge   | Chromium |  Brave   | Vivaldi  |
-:------ | :------: | :-----:  | :-----:  | :------: | :------: | :------: | :------: |
-Mac     | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 15/06/22 | 15/06/22 |
-Linux   | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 07/24/21 | 15/06/22 |
-Windows | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 15/06/22 | 15/06/22 |
+OS      |  Chrome  | Firefox  |  Opera   |   Edge   | Chromium |  Brave   | Vivaldi  | Safari   |
+:------ | :------: | :-----:  | :-----:  | :------: | :------: | :------: | :------: | :------: |
+Mac     | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 15/06/22 | 15/06/22 | 05/07/22 |
+Linux   | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 07/24/21 | 15/06/22 |    -     |
+Windows | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 15/06/22 | 15/06/22 |    -     |
 
 However I only tested on a single version of each browser and so am not sure if the cookie sqlite format changes location or format in earlier/later versions. If you experience a problem please [open an issue](https://github.com/borisbabic/browser_cookie3/issues/new) which includes details of the browser version and operating system. Also patches to support other browsers are very welcome, particularly for Chrome and Internet Explorer on Windows.
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,35 @@
+[![PyPi Downloads][PyPi-downloads]][PyPi-url]
+[![PyPi Version][PyPi-version]][PyPi-url]
+[![License][License-shield]][License-url]
+
 This is a python3 fork of [Richard Penman's Browser Cookie](https://github.com/richardpenman/browsercookie)
 
 # Browser Cookie #
 
 * ***What does it do?*** Loads cookies used by your web browser into a cookiejar object.
 * ***Why is it useful?*** This means you can use python to download and get the same content you see in the web browser without needing to login.
-* ***Which browsers are supported?*** Currently Chrome, Firefox, Opera, Edge, Chromium, and Brave.
+* ***Which browsers are supported?*** Currently Chrome, Firefox, Opera, Edge, Chromium, Brave, and Vivaldi.
 * ***How are the cookies stored?*** All currently-supported browsers store cookies in a sqlite database in your home directory.
 
 ## Install ##
+```bash
+pip3 install browser-cookie3
 ```
-#!bash
-
-    pip3 install browser-cookie3
-
-```
-
 
 ## Usage ##
 
 Here is a *dangerous* hack to extract the title from a webpage:
-```
+```python
 #!python
+
 >>> import re
 >>> get_title = lambda html: re.findall('<title>(.*?)</title>', html, flags=re.DOTALL)[0].strip()
 ```
 
 And here is the webpage title when downloaded normally:
-```
+```python
 #!python
+
 >>> import urllib2
 >>> url = 'https://bitbucket.org/'
 >>> public_html = urllib2.urlopen(url).read()
@@ -36,7 +38,7 @@ And here is the webpage title when downloaded normally:
 ```
 
 Now let's try with browser_cookie3 - make sure you are logged into Bitbucket in Firefox before trying this example:
-```
+```python
 #!python
 
 >>> import browser_cookie3
@@ -50,7 +52,7 @@ Now let's try with browser_cookie3 - make sure you are logged into Bitbucket in 
 You should see your own username here, meaning the module successfully loaded the cookies from Firefox.
 
 Here is an alternative example with [requests](http://docs.python-requests.org/en/latest/), this time loading the Chrome cookies. Again make sure you are logged into Bitbucket in Chrome before running this:
-```
+```python
 #!python
 
 >>> import browser_cookie3
@@ -62,7 +64,7 @@ Here is an alternative example with [requests](http://docs.python-requests.org/e
 ```
 
 Alternatively if you don't know/care which browser has the cookies you want then all available browser cookies can be loaded:
-```
+```python
 #!python
 
 >>> import browser_cookie3
@@ -74,7 +76,7 @@ Alternatively if you don't know/care which browser has the cookies you want then
 ```
 
 Alternatively if you are only interested in cookies from a specific domain, you can specify a domain filter.
-```
+```python
 #!python
 
 >>> import browser_cookie3
@@ -93,16 +95,6 @@ Run `google-chrome-stable --user-data-dir=browser_cookie3 #replace google-chrome
 
 If you want to share a cookie file then visit some site that will generate cookie (without logging in!), example https://www.theverge.com/ will save cookies after you accept the GDPR notice.
 
-### Gnome, Brave (and other Chromium browsers) password storage
-
-If `browser_cookie3` is unable to decrypt cookies, you can start your browser with the `--password-store=gnome-keyring` parameter.  For example:
-
-```sh
-/usr/bin/brave-browser-stable --password-store=gnome-keyring %U
-```
-
-This is confirmed to work with the Brave browser but may also work with other Chromium based browsers as well.
-
 ## Planned backwards incompatible changes for 1.0
 - more sensible cookie file checking order, like first using the default defined in profiles.ini for firefox
 
@@ -114,17 +106,24 @@ So far the following platforms are supported:
 * **Opera:** Linux, OSX, Windows
 * **Edge:** Linux, OSX, Windows
 * **Chromium:** Linux, OSX, Windows
-* **Brave** Linux (using Gnome keyring), OSX, Windows
+* **Brave** Linux, OSX, Windows
+* **Vivaldi** Linux, OSX, Windows
 
 ## Testing Dates  (dd/mm/yy) ##
 
-OS      |  Chrome  | Firefox |  Opera  |   Edge   | Chromium | Brave    |
-:------ | :------: | :-----: | :-----: | :------: | :------: | :------: |
-Mac     | 09/12/20 |09/12/20 |09/12/20 | 09/12/20 | 09/12/20 |  |
-Linux   | 09/12/20 |09/12/20 |09/12/20 | 09/12/20 | 09/12/20 | 07/24/21 |
-Windows | 09/12/20 |09/12/20 |09/12/20 | 09/12/20 | 09/12/20 | |
+OS      |  Chrome  | Firefox  |  Opera   |   Edge   | Chromium |  Brave   | Vivaldi  |
+:------ | :------: | :-----:  | :-----:  | :------: | :------: | :------: | :------: |
+Mac     | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 15/06/22 | 15/06/22 |
+Linux   | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 07/24/21 | 15/06/22 |
+Windows | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 09/12/20 | 15/06/22 | 15/06/22 |
 
 However I only tested on a single version of each browser and so am not sure if the cookie sqlite format changes location or format in earlier/later versions. If you experience a problem please [open an issue](https://github.com/borisbabic/browser_cookie3/issues/new) which includes details of the browser version and operating system. Also patches to support other browsers are very welcome, particularly for Chrome and Internet Explorer on Windows.
 
 ## Acknowledgements ##
 Special thanks to Nathan Henrie for his example of [how to decode the Chrome cookies](http://n8henrie.com/2013/11/use-chromes-cookies-for-easier-downloading-with-python-requests/).
+
+[PyPi-downloads]: https://img.shields.io/pypi/dm/browser-cookie3
+[PyPi-url]: https://pypi.org/project/browser-cookie3/
+[License-shield]: https://img.shields.io/github/license/borisbabic/browser_cookie3?color=00aaaa
+[License-url]: https://github.com/borisbabic/browser_cookie3/blob/master/LICENSE
+[PyPi-version]: https://img.shields.io/pypi/v/browser-cookie3?color=00aa00

--- a/__init__.py
+++ b/__init__.py
@@ -646,7 +646,11 @@ class Firefox:
             user_data_path = os.path.expanduser(
                 '~/Library/Application Support/Firefox')
         elif sys.platform.startswith('linux'):
-            user_data_path = os.path.expanduser('~/.mozilla/firefox')
+            general_path = os.path.expanduser('~/.mozilla/firefox')
+            if os.path.isdir(general_path):
+                user_data_path = general_path
+            else:
+                user_data_path = os.path.expanduser('~/snap/firefox/common/.mozilla/firefox')
         elif sys.platform == 'win32':
             user_data_path = os.path.join(
                 os.environ.get('APPDATA'), 'Mozilla', 'Firefox')

--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,7 @@
 
 import os
 import os.path
+import struct
 import sys
 import glob
 import http.cookiejar
@@ -10,6 +11,7 @@ import tempfile
 import lz4.block
 import configparser
 import base64
+from io import BytesIO
 from Crypto.Cipher import AES
 from typing import Union
 
@@ -717,6 +719,107 @@ class Firefox:
         return cj
 
 
+class Safari:
+    """Class for Safari"""
+
+    APPLE_TO_UNIX_TIME = 978307200
+    NEW_ISSUE_MESSAGE = 'Page format changed.\nPlease create a new issue on: https://github.com/borisbabic/browser_cookie3/issues/new'
+
+    def __init__(self, cookie_file=None, domain_name="") -> None:
+        self.__offset = 0
+        self.__domain_name = domain_name
+        self.__buffer = None
+        self.__open_file(cookie_file)
+        self.__parse_header()
+
+    def __del__(self):
+        if self.__buffer:
+            self.__buffer.close()
+    
+    def __open_file(self, cookie_file):
+        if cookie_file is None:
+            cookie_file = os.path.expanduser('~/Library/Cookies/Cookies.binarycookies')
+        if not os.path.exists(cookie_file):
+            raise BrowserCookieError('Can not find Safari cookie file')
+        self.__buffer = open(cookie_file, 'rb')
+    
+    def __read_file(self, size:int, offset:int=None):
+        if offset is not None:
+            self.__offset = offset
+        self.__buffer.seek(self.__offset)
+        self.__offset += size
+        return BytesIO(self.__buffer.read(size))
+
+    def __parse_header(self):
+        assert self.__buffer.read(4) == b'cook', 'Not a safari cookie file'
+        self.__total_page = struct.unpack('>I', self.__buffer.read(4))[0]
+        
+        self.__page_sizes = []
+        for _ in range(self.__total_page):
+            self.__page_sizes.append(struct.unpack('>I', self.__buffer.read(4))[0])
+
+    @staticmethod
+    def __read_until_null(file:BytesIO, decode:bool=True):
+        data = []
+        while True:
+            byte = file.read(1)
+            if byte == b'\x00':
+                break
+            data.append(byte)
+        data = b''.join(data)
+        if decode:
+            data = data.decode('utf-8')
+        return data
+
+    def __parse_cookie(self, page:BytesIO, cookie_offset:int):
+        page.seek(cookie_offset)
+        cookie_size = struct.unpack('<Q', page.read(8))[0]
+        flags = struct.unpack('<Q', page.read(8))[0]
+        is_secure = bool(flags & 0x1)
+        is_httponly = bool(flags & 0x4)
+        
+        host_offset = struct.unpack('<I', page.read(4))[0]
+        name_offset = struct.unpack('<I', page.read(4))[0]
+        path_offset = struct.unpack('<I', page.read(4))[0]
+        value_offset = struct.unpack('<I', page.read(4))[0]
+
+        assert page.read(8) == b'\x00' * 8, self.NEW_ISSUE_MESSAGE
+        expiry_date = int(struct.unpack('<d', page.read(8))[0] + self.APPLE_TO_UNIX_TIME) # convert to unix time
+        access_time = int(struct.unpack('<d', page.read(8))[0] + self.APPLE_TO_UNIX_TIME) # convert to unix time
+        
+        name = self.__read_until_null(page)
+        value = self.__read_until_null(page)
+        host = self.__read_until_null(page)
+        path = self.__read_until_null(page)
+
+        return create_cookie(host, path, is_secure, expiry_date, name, value, is_httponly)
+
+    def __domain_filter(self, cookie: http.cookiejar.Cookie):
+        if not self.__domain_name:
+            return True
+        return self.__domain_name in cookie.domain
+
+    def __parse_page(self, page_index:int):
+        offset = 8 + self.__total_page * 4 + sum(self.__page_sizes[:page_index])
+        page = self.__read_file(self.__page_sizes[page_index], offset)
+        assert page.read(4) == b'\x00\x00\x01\x00', self.NEW_ISSUE_MESSAGE
+        n_cookies = struct.unpack('<I', page.read(4))[0]
+        cookie_offsets = []
+        for _ in range(n_cookies):
+            cookie_offsets.append(struct.unpack('<I', page.read(4))[0])
+        assert page.read(4) == b'\x00\x00\x00\x00', self.NEW_ISSUE_MESSAGE
+        
+        for offset in cookie_offsets:
+            yield self.__parse_cookie(page, offset)
+    
+    def load(self):
+        cj = http.cookiejar.CookieJar()
+        for i in range(self.__total_page):
+            for cookie in self.__parse_page(i):
+                if self.__domain_filter(cookie):
+                    cj.set_cookie(cookie)
+        return cj
+
 def create_cookie(host, path, secure, expires, name, value, http_only):
     """Shortcut function to create a cookie"""
     # HTTPOnly flag goes in _rest, if present (see https://github.com/python/cpython/pull/17471/files#r511187060)
@@ -773,13 +876,18 @@ def firefox(cookie_file=None, domain_name=""):
     """
     return Firefox(cookie_file, domain_name).load()
 
+def safari(cookie_file=None, domain_name=""):
+    """Returns a cookiejar of the cookies and sessions used by Safari. Optionally
+    pass in a domain name to only load cookies from the specified domain
+    """
+    return Safari(cookie_file, domain_name).load()
 
 def load(domain_name=""):
     """Try to load cookies from all supported browsers and return combined cookiejar
     Optionally pass in a domain name to only load cookies from the specified domain
     """
     cj = http.cookiejar.CookieJar()
-    for cookie_fn in [chrome, chromium, opera, brave, edge, vivaldi, firefox]:
+    for cookie_fn in [chrome, chromium, opera, brave, edge, vivaldi, firefox, safari]:
         try:
             for cookie in cookie_fn(domain_name=domain_name):
                 cj.set_cookie(cookie)

--- a/__init__.py
+++ b/__init__.py
@@ -42,7 +42,8 @@ def create_local_copy(cookie_file):
     if os.path.exists(cookie_file):
         # copy to random name in tmp folder
         tmp_cookie_file = tempfile.NamedTemporaryFile(suffix='.sqlite').name
-        open(tmp_cookie_file, 'wb').write(open(cookie_file, 'rb').read())
+        with open(tmp_cookie_file, "wb") as f1, open(cookie_file, "rb") as f2:
+            f1.write(f2.read())
         return tmp_cookie_file
     else:
         raise BrowserCookieError('Can not find cookie file at: ' + cookie_file)

--- a/__init__.py
+++ b/__init__.py
@@ -730,6 +730,10 @@ class Safari:
 
     APPLE_TO_UNIX_TIME = 978307200
     NEW_ISSUE_MESSAGE = 'Page format changed.\nPlease create a new issue on: https://github.com/borisbabic/browser_cookie3/issues/new'
+    safari_cookies = [
+        '~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies',
+        '~/Library/Cookies/Cookies.binarycookies'
+    ]
 
     def __init__(self, cookie_file=None, domain_name="") -> None:
         self.__offset = 0
@@ -744,7 +748,7 @@ class Safari:
     
     def __open_file(self, cookie_file):
         if cookie_file is None:
-            cookie_file = os.path.expanduser('~/Library/Cookies/Cookies.binarycookies')
+            cookie_file = expand_paths(self.safari_cookies,'osx')
         if not os.path.exists(cookie_file):
             raise BrowserCookieError('Can not find Safari cookie file')
         self.__buffer = open(cookie_file, 'rb')
@@ -779,8 +783,10 @@ class Safari:
 
     def __parse_cookie(self, page:BytesIO, cookie_offset:int):
         page.seek(cookie_offset)
-        cookie_size = struct.unpack('<Q', page.read(8))[0]
-        flags = struct.unpack('<Q', page.read(8))[0]
+        cookie_size = struct.unpack('<I', page.read(4))[0]
+        page.seek(4, 1) # skip 4-bytes unknown data
+        flags = struct.unpack('<I', page.read(4))[0]
+        page.seek(4, 1) # skip 4-bytes unknown data
         is_secure = bool(flags & 0x1)
         is_httponly = bool(flags & 0x4)
         
@@ -788,15 +794,25 @@ class Safari:
         name_offset = struct.unpack('<I', page.read(4))[0]
         path_offset = struct.unpack('<I', page.read(4))[0]
         value_offset = struct.unpack('<I', page.read(4))[0]
+        abbr_offset = struct.unpack('<H', page.read(2))[0]
+        if abbr_offset == 0:
+            page.seek(-2, 1) # go back
 
         assert page.read(8) == b'\x00' * 8, self.NEW_ISSUE_MESSAGE
         expiry_date = int(struct.unpack('<d', page.read(8))[0] + self.APPLE_TO_UNIX_TIME) # convert to unix time
         access_time = int(struct.unpack('<d', page.read(8))[0] + self.APPLE_TO_UNIX_TIME) # convert to unix time
-        
-        name = self.__read_until_null(page)
-        value = self.__read_until_null(page)
+
+        page.seek(cookie_offset + host_offset, 0)
         host = self.__read_until_null(page)
+        page.seek(cookie_offset + name_offset, 0)
+        name = self.__read_until_null(page)
+        page.seek(cookie_offset + path_offset, 0)
         path = self.__read_until_null(page)
+        page.seek(cookie_offset + value_offset, 0)
+        value = self.__read_until_null(page)
+        if abbr_offset:
+            page.seek(cookie_offset + abbr_offset, 0)
+            abbr = self.__read_until_null(page)
 
         return create_cookie(host, path, is_secure, expiry_date, name, value, is_httponly)
 

--- a/__init__.py
+++ b/__init__.py
@@ -247,7 +247,7 @@ class ChromiumBased:
 
             cookie_file = self.cookie_file or expand_paths(osx_cookies,'osx')
 
-        elif sys.platform.startswith('linux'):
+        elif sys.platform.startswith('linux') or 'bsd' in sys.platform.lower():
             my_pass = get_linux_pass(os_crypt_name)
 
             iterations = 1
@@ -257,6 +257,7 @@ class ChromiumBased:
                                   iterations=iterations).read(self.length)
 
             cookie_file = self.cookie_file or expand_paths(linux_cookies, 'linux')
+
 
         elif sys.platform == "win32":
             key_file = self.key_file or expand_paths(windows_keys,'windows')
@@ -646,7 +647,7 @@ class Firefox:
         if sys.platform == 'darwin':
             user_data_path = os.path.expanduser(
                 '~/Library/Application Support/Firefox')
-        elif sys.platform.startswith('linux'):
+        elif sys.platform.startswith('linux') or 'bsd' in sys.platform.lower():
             general_path = os.path.expanduser('~/.mozilla/firefox')
             if os.path.isdir(general_path):
                 user_data_path = general_path

--- a/__init__.py
+++ b/__init__.py
@@ -126,7 +126,7 @@ def get_secretstorage_password(os_crypt_name):
     # https://github.com/n8henrie/pycookiecheat/issues/12
 
     import secretstorage
-    
+
     connection = secretstorage.dbus_init()
     collection = secretstorage.get_default_collection(connection)
     secret = None
@@ -161,7 +161,7 @@ def get_linux_pass(os_crypt_name):
         raise
     except:
         pass
-    
+
     try:
         return get_kde_wallet_password(os_crypt_name)
     except KeyboardInterrupt:
@@ -233,8 +233,8 @@ class ChromiumBased:
             my_pass = my_pass.encode('utf-8')
 
             iterations = 1003  # number of pbkdf2 iterations on mac
-            self.key = PBKDF2(my_pass, self.salt,
-                              iterations=iterations).read(self.length)
+            self.v10_key = PBKDF2(my_pass, self.salt,
+                                  iterations=iterations).read(self.length)
 
             cookie_file = self.cookie_file or expand_paths(osx_cookies,'osx')
 
@@ -242,8 +242,10 @@ class ChromiumBased:
             my_pass = get_linux_pass(os_crypt_name)
 
             iterations = 1
-            self.key = PBKDF2(my_pass, self.salt,
-                              iterations=iterations).read(self.length)
+            self.v10_key = PBKDF2(b'peanuts', self.salt,
+                                  iterations=iterations).read(self.length)
+            self.v11_key = PBKDF2(my_pass, self.salt,
+                                  iterations=iterations).read(self.length)
 
             cookie_file = self.cookie_file or expand_paths(linux_cookies, 'linux')
 
@@ -257,7 +259,7 @@ class ChromiumBased:
 
                     # Decode Key, get rid of DPAPI prefix, unprotect data
                     keydpapi = base64.standard_b64decode(key64)[5:]
-                    _, self.key = crypt_unprotect_data(keydpapi, is_key=True)
+                    _, self.v10_key = crypt_unprotect_data(keydpapi, is_key=True)
 
             # get cookie file from APPDATA
 
@@ -343,14 +345,14 @@ class ChromiumBased:
 
             # Fix for change in Chrome 80
             except RuntimeError:  # Failed to decrypt the cipher text with DPAPI
-                if not self.key:
+                if not self.v10_key:
                     raise RuntimeError(
                         'Failed to decrypt the cipher text with DPAPI and no AES key.')
                 # Encrypted cookies should be prefixed with 'v10' according to the
                 # Chromium code. Strip it off.
                 encrypted_value = encrypted_value[3:]
                 nonce, tag = encrypted_value[:12], encrypted_value[-16:]
-                aes = AES.new(self.key, AES.MODE_GCM, nonce=nonce)
+                aes = AES.new(self.v10_key, AES.MODE_GCM, nonce=nonce)
 
                 # will rise Value Error: MAC check failed byte if the key is wrong,
                 # probably we did not got the key and used peanuts
@@ -363,13 +365,18 @@ class ChromiumBased:
         if value or (encrypted_value[:3] not in [b'v11', b'v10']):
             return value
 
-        # Encrypted cookies should be prefixed with 'v10' according to the
-        # Chromium code. Strip it off.
+        # Encrypted cookies should be prefixed with 'v10' on mac,
+        # 'v10' or 'v11' on Linux. Choose key based on this prefix.
+        # Reference in chromium code: `OSCryptImpl::DecryptString` in
+        # components/os_crypt/os_crypt_linux.cc
+        if not hasattr(self, 'v11_key'):
+            assert encrypted_value[:3] != b'v11', "v11 keys should only appear on Linux."
+        key = self.v11_key if encrypted_value[:3] == b'v11' else self.v10_key
         encrypted_value = encrypted_value[3:]
         encrypted_value_half_len = int(len(encrypted_value) / 2)
 
         cipher = pyaes.Decrypter(
-            pyaes.AESModeOfOperationCBC(self.key, self.iv))
+            pyaes.AESModeOfOperationCBC(key, self.iv))
 
         # will rise Value Error: invalid padding byte if the key is wrong,
         # probably we did not got the key and used peanuts

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='browser-cookie3',
-    version='0.14.2',
+    version='0.15.0',
     packages=['browser_cookie3'],
     # look for package contents in current directory
     package_dir={'browser_cookie3': '.'},

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='browser-cookie3',
-    version='0.15.0',
+    version='0.16.0',
     packages=['browser_cookie3'],
     # look for package contents in current directory
     package_dir={'browser_cookie3': '.'},


### PR DESCRIPTION
Fix #135

Changes:
1. Support new cookies location introduced in Safari 16.x
2. A new property found during test, probably an abbreviation, in domain `baidu.com`.