### PR TITLE
Add dbus-python as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
     author_email='boris.ivan.babic@gmail.com',
     description='Loads cookies from your browser into a cookiejar object so can download with urllib and other libraries the same content you see in the web browser.',
     url='https://github.com/borisbabic/browser_cookie3',
-    install_requires=['lz4', 'pycryptodomex'],
+    install_requires=['lz4', 'pycryptodomex', 'dbus-python'],
     license='lgpl'
 )


### PR DESCRIPTION
The code uses `import dbus` but it is not declared as a dependency in `setup.py`