### PR TITLE
Handle dbus errors if secret service is not available

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -128,7 +128,10 @@ def _get_kde_wallet_password(os_crypt_name):
     key = f'{os_crypt_name.capitalize()} Safe Storage'
     app_id = 'browser-cookie3'
     with contextlib.closing(dbus.SessionBus()) as connection:
-        kwalletd5_object = connection.get_object('org.kde.kwalletd5', '/modules/kwalletd5', False)
+        try:
+            kwalletd5_object = connection.get_object('org.kde.kwalletd5', '/modules/kwalletd5', False)
+        except dbus.exceptions.DBusException:
+            raise RuntimeError("The name org.kde.kwalletd5 was not provided by any .service files")
         kwalletd5 = dbus.Interface(kwalletd5_object, 'org.kde.KWallet')
         handle = kwalletd5.open(kwalletd5.networkWallet(), dbus.Int64(0), app_id)
         if not kwalletd5.hasFolder(handle, folder, app_id):
@@ -143,10 +146,13 @@ def _get_secretstorage_item(schema: str, application: str):
     import dbus
 
     with contextlib.closing(dbus.SessionBus()) as connection:
-        secret_service = dbus.Interface(
-            connection.get_object('org.freedesktop.secrets', '/org/freedesktop/secrets', False),
-            'org.freedesktop.Secret.Service',
-        )
+        try:
+            secret_service = dbus.Interface(
+                connection.get_object('org.freedesktop.secrets', '/org/freedesktop/secrets', False),
+                'org.freedesktop.Secret.Service',
+            )
+        except dbus.exceptions.DBusException:
+            raise RuntimeError("The name org.freedesktop.secrets was not provided by any .service files")
         object_path = secret_service.SearchItems({
             'xdg:schema': schema,
             'application': application,


### PR DESCRIPTION
On my Arch Linux, there is no software providing `org.kde.kwalletd5` via dbus. An exception is raised. The fix just catches the exception and returns. `RuntimeError` is catched by the calling function.
```python
...
  File "/home/kmille/.cache/pypoetry/virtualenvs/flixcal-CBUX2rok-py3.10/lib/python3.10/site-packages/browser_cookie3/__init__.py", line 131, in _get_kde_wallet_password                                                                      
    kwalletd5_object = connection.get_object('org.kde.kwalletd5', '/modules/kwalletd5', False)                                                                                                                                                 
  File "/home/kmille/.cache/pypoetry/virtualenvs/flixcal-CBUX2rok-py3.10/lib/python3.10/site-packages/dbus/bus.py", line 237, in get_object
    return self.ProxyObjectClass(self, bus_name, object_path,                                                                                                                                                                                  
  File "/home/kmille/.cache/pypoetry/virtualenvs/flixcal-CBUX2rok-py3.10/lib/python3.10/site-packages/dbus/proxies.py", line 250, in __init__
    self._named_service = conn.activate_name_owner(bus_name)                                                                                                                                                                                   
  File "/home/kmille/.cache/pypoetry/virtualenvs/flixcal-CBUX2rok-py3.10/lib/python3.10/site-packages/dbus/bus.py", line 178, in activate_name_owner
    self.start_service_by_name(bus_name)                                                                               
  File "/home/kmille/.cache/pypoetry/virtualenvs/flixcal-CBUX2rok-py3.10/lib/python3.10/site-packages/dbus/bus.py", line 273, in start_service_by_name
    return (True, self.call_blocking(BUS_DAEMON_NAME, BUS_DAEMON_PATH,                                                                                                                                                                         
  File "/home/kmille/.cache/pypoetry/virtualenvs/flixcal-CBUX2rok-py3.10/lib/python3.10/site-packages/dbus/connection.py", line 634, in call_blocking
    reply_message = self.send_message_with_reply_and_block(                                                                                                                                                                                    
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name org.kde.kwalletd5 was not provided by any .service files
```