### PR TITLE
Look for Firefox cookies in Snap folder first

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -724,11 +724,15 @@ class Firefox:
             user_data_path = os.path.expanduser(
                 '~/Library/Application Support/Firefox')
         elif sys.platform.startswith('linux') or 'bsd' in sys.platform.lower():
-            general_path = os.path.expanduser('~/.mozilla/firefox')
+            # Looking for cookies from a Snap based Firefox first, as some
+            # users might have profiles at both this and the other location,
+            # as they were migrated to Snap by their OS at some point, leaving
+            # cookies at the other location outdated.
+            general_path = os.path.expanduser('~/snap/firefox/common/.mozilla/firefox')
             if os.path.isdir(general_path):
                 user_data_path = general_path
             else:
-                user_data_path = os.path.expanduser('~/snap/firefox/common/.mozilla/firefox')
+                user_data_path = os.path.expanduser('~/.mozilla/firefox')
         elif sys.platform == 'win32':
             user_data_path = os.path.join(
                 os.environ.get('APPDATA'), 'Mozilla', 'Firefox')


### PR DESCRIPTION
Some user might have Firefox profiles in two places: ~/.mozilla/firefox and ~/snap/firefox/common/.mozilla/firefox. This could be due to the fact that some OS'es (e.g. Ubuntu) at some point switched from providing Firefox via their regular packaging system to providing it via Snap. In that case, the Firefox profile was copied and an older version of the profile was left at the old location. Thus it makes sense to look at the Snap based Firefox profile location first, instead of the other way around.