### PR TITLE
No file copying, and no Windows import override needed

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,12 +14,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Union
 
-try:
-    # should use pysqlite2 to read the cookies.sqlite on Windows
-    # otherwise will raise the "sqlite3.DatabaseError: file is encrypted or is not a database" exception
-    from pysqlite2 import dbapi2 as sqlite3
-except ImportError:
-    import sqlite3
+import sqlite3
 
 if sys.platform.startswith('linux') or 'bsd' in sys.platform.lower():
     try:


### PR DESCRIPTION
* Don't create unnecessary copies of sqlite3 files
    
    This takes up time and disk space unnecessarily.
    
    SQLite3 is able to open databases in a read-only, lock-free mode (see
    "nolock" in https://www.sqlite.org/c3ref/open.html).  Tested on Linux with
    Chrome, Chromium, and Firefox; loading cookies from databases opened in this
    mode appear to work fine.
    
    Somewhat frustratingly and confusingly, this option seems only to be
    accessible by using 'file:' URIs, and not via any other API (see
    https://www.codejam.info/2021/10/bypass-sqlite-exclusive-lock.html).
    
    Fortunately, the standard library module pathlib (Python 3.4+) makes it easy
    to convert paths to 'file:' URIs in a cross-platform way.

* Remove ancient import override for Windows
    
    The replacement of sqlite3 with pysqlite2 on Windows dates back to the
    initial 2015 commit to the parent repository
    (https://github.com/richardpenman/browsercookie/commit/7828992a9a53ac6b1ecc368c1c1a519ebbd52aad).
    
    pysqlite2 is no longer maintained, and there no longer appears to be any bug
    or limitation preventing sqlite3 from opening Chrome/Firefox databases on
    Windows.