### PR TITLE
Try to open sqlite database in readonly mode with immutable=1 option

### DIFF
--- a/browser_cookie3/__init__.py
+++ b/browser_cookie3/__init__.py
@@ -332,7 +332,7 @@ class _DatabaseConnetion():
 
     def __sqlite3_connect_readonly(self):
         uri = Path(self.__database_file).absolute().as_uri()
-        for options in ('?mode=ro', '?mode=ro&nolock=1'):
+        for options in ('?mode=ro', '?mode=ro&nolock=1', '?mode=ro&immutable=1'):
             try:
                 con = sqlite3.connect(uri + options, uri=True)
             except sqlite3.OperationalError:


### PR DESCRIPTION
According to https://www.sqlite.org/c3ref/open.html an "immutable" option allows to get a read-only access to sqlite database even if an exclusive lock is taken by a web browser ( e.g. Firefox ). It might be useful for cases when someone wants to run some script that relates on read-only access to browser's sqlite based cookie storage using browser_cookie3 library, together with browser.   