### PR TITLE
Add support for browsers lynx and w3m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- [MODULE] Added new browser support: Lynx and W3m
 ### 0.19.1
 - [Firefox based] Fix an error when `load()` fails if librewolf or firefox is not installed
 ### 0.19.0

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is a python3 fork of [Richard Penman's Browser Cookie](https://github.com/r
 
 * ***What does it do?*** Loads cookies used by your web browser into a cookiejar object.
 * ***Why is it useful?*** This means you can use python to download and get the same content you see in the web browser without needing to login.
-* ***Which browsers are supported?*** Chrome, Firefox, LibreWolf, Opera, Opera GX, Edge, Chromium, Brave, Vivaldi, and Safari.
-* ***How are the cookies stored?*** All currently-supported browsers store cookies in a sqlite database in your home directory.
+* ***Which browsers are supported?*** Chrome, Firefox, LibreWolf, Opera, Opera GX, Edge, Chromium, Brave, Vivaldi, Safari, W3m and Lynx.
+* ***How are the cookies stored?*** Most currently-supported browsers store cookies in a sqlite database in your home directory. Some browsers store them in tab-separated txt files.
 
 ## Install
 ```bash
@@ -111,6 +111,8 @@ So far the following platforms are supported:
 * **Brave:** Linux, MacOS, Windows
 * **Vivaldi:** Linux, MacOS, Windows
 * **Safari:** MacOS
+* **W3m:** Linux
+* **Lynx:** Linux
 
 You are welcome to contribute support for other browsers, or other platforms.
 
@@ -128,6 +130,8 @@ Chromium | 07/24/21 | 15/06/22 | 15/06/22 |
 Brave    | 31/01/23 | 31/01/23 | 31/01/23 |
 Vivaldi  | 31/01/23 | 31/01/23 | 15/06/22 |
 Safari   |    -     | 31/01/23 |    -     |
+W3m      | 05/07/23 |    -     |    -     |
+Lynx     | 05/07/23 |    -     |    -     |
 
 However I only tested on a single version of each browser and so am not sure if the cookie sqlite format changes location or format in earlier/later versions. If you experience a problem please [open an issue](https://github.com/borisbabic/browser_cookie3/issues/new) which includes details of the browser version and operating system. Also patches to support other browsers are very welcome, particularly for Chrome and Internet Explorer on Windows.
 

--- a/browser_cookie3/__init__.py
+++ b/browser_cookie3/__init__.py
@@ -1145,6 +1145,79 @@ class Safari:
         return cj
 
 
+class Lynx:
+    """Class for Lynx"""
+
+    lynx_cookies = [
+        '~/.lynx_cookies', # most systems, see lynx man page
+        '~/cookies'        # MS-DOS
+    ]
+
+    def __init__(self, cookie_file=None, domain_name=""):
+        self.cookie_file = _expand_paths(cookie_file or self.lynx_cookies, 'linux')
+        self.domain_name = domain_name
+
+    def load(self):
+        cj = http.cookiejar.CookieJar()
+        if not self.cookie_file:
+            raise BrowserCookieError('Cannot find Lynx cookie file')
+        with open(self.cookie_file) as f:
+            for line in f.read().splitlines():
+                # documentation in source code of lynx, file src/LYCookie.c
+                domain, domain_specified, path, secure, expires, name, value = \
+                        [None if word == '' else word for word in line.split('\t')]
+                domain_specified = domain_specified == 'TRUE'
+                secure = secure == 'TRUE'
+                if domain.find(self.domain_name) >= 0:
+                    cookie = create_cookie(domain, path, secure, expires, name,
+                            value, False)
+                    cj.set_cookie(cookie)
+        return cj
+
+
+class W3m:
+    """Class for W3m"""
+
+    # see documentation in source code of w3m, file fm.h
+    COO_USE = 1
+    COO_SECURE = 2
+    COO_DOMAIN = 4
+    COO_PATH = 8
+    COO_DISCARD = 16
+    COO_OVERRIDE = 32
+    w3m_cookies = [
+        '~/.w3m/cookie'
+    ]
+
+    def __init__(self, cookie_file=None, domain_name=""):
+        self.cookie_file = _expand_paths(cookie_file or self.w3m_cookies, 'linux')
+        self.domain_name = domain_name
+
+    def load(self):
+        cj = http.cookiejar.CookieJar()
+        if not self.cookie_file:
+            raise BrowserCookieError('Cannot find W3m cookie file')
+        with open(self.cookie_file) as f:
+            for line in f.read().splitlines():
+                # see documentation in source code of w3m, file cookie.c
+                url, name, value, expires, domain, path, flag, version, comment, \
+                        port, comment_url = \
+                        [None if word == '' else word for word in line.split('\t')]
+                flag = int(flag)
+                expires = int(expires)
+                secure = bool(flag & self.COO_SECURE)
+                domain_specified = bool(flag & self.COO_DOMAIN)
+                path_specified = bool(flag & self.COO_PATH)
+                discard = bool(flag & self.COO_DISCARD)
+                if domain.find(self.domain_name) >= 0:
+                    cookie = http.cookiejar.Cookie(version, name, value, port,
+                            bool(port), domain, domain_specified,
+                            domain.startswith('.'), path, path_specified, secure,
+                            expires, discard, comment, comment_url, {})
+                    cj.set_cookie(cookie)
+        return cj
+
+
 def create_cookie(host, path, secure, expires, name, value, http_only):
     """Shortcut function to create a cookie"""
     # HTTPOnly flag goes in _rest, if present (see https://github.com/python/cpython/pull/17471/files#r511187060)
@@ -1221,6 +1294,20 @@ def safari(cookie_file=None, domain_name=""):
     pass in a domain name to only load cookies from the specified domain
     """
     return Safari(cookie_file, domain_name).load()
+
+
+def lynx(cookie_file=None, domain_name=""):
+    """Returns a cookiejar of the cookies and sessions used by Lynx. Optionally
+    pass in a domain name to only load cookies from the specified domain
+    """
+    return Lynx(cookie_file, domain_name).load()
+
+
+def w3m(cookie_file=None, domain_name=""):
+    """Returns a cookiejar of the cookies and sessions used by W3m. Optionally
+    pass in a domain name to only load cookies from the specified domain
+    """
+    return W3m(cookie_file, domain_name).load()
 
 
 def load(domain_name=""):


### PR DESCRIPTION
These are two text-based browsers from 1992 and 1995, which are both still maintained. Their cookie files are just simple tab-separated text files. This PR simply parses these text files and reads the cookies from them. For now I implemented only Linux support. Lynx runs also on Windows, but probably this needs adjustments which I will not implement.