### PR TITLE
Add support for doing a shadowcopy on win32 if we can't get the cookies via normal ways

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
         'lz4',
         'pycryptodomex',
         'dbus-python; python_version < "3.7" and ("bsd" in sys_platform or sys_platform == "linux")',
-        'jeepney; python_version >= "3.7" and ("bsd" in sys_platform or sys_platform == "linux")'
+        'jeepney; python_version >= "3.7" and ("bsd" in sys_platform or sys_platform == "linux")',
+        'shadowcopy; python_version >= "3.7" and platform_system == "Windows"',
     ],
     license='lgpl'
 )


### PR DESCRIPTION
This works for me if running as admin. If not running as admin, the exception from shadowcopy makes it up:

```
In [2]: c = browser_cookie3.chrome()
---------------------------------------------------------------------------
RequiresAdminError                        Traceback (most recent call last)
Cell In [2], line 1
----> 1 c = browser_cookie3.chrome()

File ~\Desktop\browser_cookie3\browser_cookie3\__init__.py:1189, in chrome(cookie_file, domain_name, key_file)
   1185 def chrome(cookie_file=None, domain_name="", key_file=None):
   1186     """Returns a cookiejar of the cookies used by Chrome. Optionally pass in a
   1187     domain name to only load cookies from the specified domain
   1188     """
-> 1189     return Chrome(cookie_file, domain_name, key_file).load()

File ~\Desktop\browser_cookie3\browser_cookie3\__init__.py:518, in ChromiumBased.load(self)
    515 """Load sqlite cookies into a cookiejar"""
    516 cj = http.cookiejar.CookieJar()
--> 518 with _DatabaseConnetion(self.cookie_file) as con:
    519     con.text_factory = _text_factory
    520     cur = con.cursor()

File ~\Desktop\browser_cookie3\browser_cookie3\__init__.py:364, in _DatabaseConnetion.__enter__(self)
    363 def __enter__(self):
--> 364     return self.get_connection()

File ~\Desktop\browser_cookie3\browser_cookie3\__init__.py:412, in _DatabaseConnetion.get_connection(self)
    410     return self.__connection
    411 for method in self.__methods:
--> 412     con = method()
    413     if con is not None:
    414         self.__connection = con

File ~\Desktop\browser_cookie3\browser_cookie3\__init__.py:403, in _DatabaseConnetion.__get_connection_shadowcopy(self)
    399     raise RuntimeError("shadowcopy is not available")
    401 self.__temp_cookie_file = tempfile.NamedTemporaryFile(
    402     suffix='.sqlite').name
--> 403 shadowcopy.shadow_copy(self.__database_file, self.__temp_cookie_file)
    404 con = sqlite3.connect(self.__temp_cookie_file)
    405 if self.__check_connection_ok(con):

File C:\Python311\Lib\site-packages\shadowcopy\shadow.py:46, in shadow_copy(src, dst)
     43     raise OSUnsupportedError(f"This OS is not supported: {os.name}")
     45 if not _is_admin():
---> 46     raise RequiresAdminError("This operation requires admin. Please run as admin.")
     48 if not Path(src).is_file():
     49     raise PathIsNotToFile(f"The src path is not a file: {src}")

RequiresAdminError: This operation requires admin. Please run as admin.
```

We can catch that and do something if you'd like :) 

This works as a workaround to https://github.com/borisbabic/browser_cookie3/issues/180