### PR TITLE
Fix crash on linux with Arc

### DIFF
--- a/browser_cookie3/__init__.py
+++ b/browser_cookie3/__init__.py
@@ -693,6 +693,7 @@ class Arc(ChromiumBased):
 
     def __init__(self, cookie_file=None, domain_name="", key_file=None):
         args = {
+            'linux_cookies': [],  # Not available on Linux
             'osx_cookies': _genarate_nix_paths_chromium(
                 [
                     '~/Library/Application Support/Arc/User Data/Default/Cookies',


### PR DESCRIPTION
Fix crash on linux with Arc

Was getting this error using `browser_cookie3.load`:

```
  File "/home/teticio/ML/kindle2pdf/.venv/lib/python3.10/site-packages/browser_cookie3/__init__.py", line 1414, in load
    for cookie in cookie_fn(domain_name=domain_name):
  File "/home/teticio/ML/kindle2pdf/.venv/lib/python3.10/site-packages/browser_cookie3/__init__.py", line 1327, in arc
    return Arc(cookie_file, domain_name, key_file).load()
  File "/home/teticio/ML/kindle2pdf/.venv/lib/python3.10/site-packages/browser_cookie3/__init__.py", line 707, in __init__
    super().__init__(browser='Arc', cookie_file=cookie_file,
  File "/home/teticio/ML/kindle2pdf/.venv/lib/python3.10/site-packages/browser_cookie3/__init__.py", line 445, in __init__
    self.__add_key_and_cookie_file(**kwargs)
  File "/home/teticio/ML/kindle2pdf/.venv/lib/python3.10/site-packages/browser_cookie3/__init__.py", line 472, in __add_key_and_cookie_file
    cookie_file = self.cookie_file or _expand_paths(
  File "/home/teticio/ML/kindle2pdf/.venv/lib/python3.10/site-packages/browser_cookie3/__init__.py", line 153, in _expand_paths
    return next(_expand_paths_impl(paths, os_name), None)
  File "/home/teticio/ML/kindle2pdf/.venv/lib/python3.10/site-packages/browser_cookie3/__init__.py", line 144, in _expand_paths_impl
    for path in paths:
  File "/usr/lib/python3.10/posixpath.py", line 232, in expanduser
    path = os.fspath(path)
```

Fix was to add this line to `Arc`:
```
            'linux_cookies': [],  # Not available on Linux
```