### PR TITLE
Fix the TypeError when calling browser_cookie3.load()

### DIFF
--- a/browser_cookie3/__init__.py
+++ b/browser_cookie3/__init__.py
@@ -133,6 +133,9 @@ def _expand_paths_impl(paths: list, os_name: str):
     os_name = os_name.lower()
     assert os_name in ['windows', 'osx', 'linux']
 
+    if paths is None:
+        paths = []
+
     if not isinstance(paths, list):
         paths = [paths]
 


### PR DESCRIPTION
This is another way to fix the issue, which should work on all browsers with operating system cookie file lists that aren't populated.