### PR TITLE
Handle empty path expansion

### DIFF
--- a/browser_cookie3/__init__.py
+++ b/browser_cookie3/__init__.py
@@ -127,9 +127,12 @@ def _expand_win_path(path: Union[dict, str]):
     return os.path.join(os.getenv(path['env'], ''), path['path'])
 
 
-def _expand_paths_impl(paths: list, os_name: str):
+def _expand_paths_impl(paths: list | None, os_name: str):
     """Expands user paths on Linux, OSX, and windows"""
-
+    
+    if paths is None:
+         paths = []
+    
     os_name = os_name.lower()
     assert os_name in ['windows', 'osx', 'linux']
 


### PR DESCRIPTION
I was getting an issue on Linux specifically

```py
  File "site-packages/browser_cookie3/__init__.py", line 144, in _expand_paths_impl
    for path in paths:
                ^^^^^
  File "<frozen posixpath>", line 232, in expanduser
```
Investigation showed that 

https://github.com/borisbabic/browser_cookie3/blob/03895797e48dd107806db171d8392c562151807d/browser_cookie3/__init__.py#L469-L474

has an empty path for `linux_cookies` for browsers such as `Arc` which is I believe correct since there is no linux path for this browser

The issue is that the current implementation tries all browsers and for any browser where the linuxpath is not set it would error for linux.

To fix this I altered `_expand_path_impl` to handle empty (i.e. None) as an empty list instead

https://github.com/borisbabic/browser_cookie3/blob/03895797e48dd107806db171d8392c562151807d/browser_cookie3/__init__.py#L130-L133

```py
def _expand_paths_impl(paths: list | None, os_name: str):
    """Expands user paths on Linux, OSX, and windows"""
    if paths is None:
         paths = []
    os_name = os_name.lower()
```